### PR TITLE
[MAINTENANCE] Remaining integration tests around GXValidateCheckpointOperator

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@ import great_expectations as gx
 from typing import Callable, Generator
 from great_expectations.data_context import AbstractDataContext
 from sqlalchemy import create_engine, text
+from pathlib import Path
 
 import pytest
 import string
@@ -126,3 +127,14 @@ def load_postgres_data(
     engine = create_engine(url=postgres_connection_string)
     with engine.connect() as conn, conn.begin():
         conn.execute(text(f"DROP TABLE {table_name};"))
+
+
+@pytest.fixture
+def load_csv_data() -> Generator[Callable[[Path, list[dict]], None], None, None]:
+    def _load_csv_data(path: Path, data: list[dict]) -> None:
+        with path.open("w") as f:
+            f.write("name,age\n")
+            for row in data:
+                f.write(f"{row['name']},{row['age']}\n")
+
+    yield _load_csv_data

--- a/tests/integration/test_validate_checkpoint_operator.py
+++ b/tests/integration/test_validate_checkpoint_operator.py
@@ -115,6 +115,11 @@ class TestValidateCheckpointOperator:
         result = validate_cloud_checkpoint.execute(context={})
 
         assert result["success"] is True
+        # make sure we have something that looks like a valid result url
+        assert (
+            "https://app.greatexpectations.io/organizations/"
+            in result["validation_results"][0]["result_url"]
+        )
 
     def test_with_file_context(
         self,

--- a/tests/integration/test_validate_checkpoint_operator.py
+++ b/tests/integration/test_validate_checkpoint_operator.py
@@ -5,7 +5,8 @@ import pandas as pd
 from typing import Callable
 import great_expectations as gx
 import great_expectations.expectations as gxe
-from great_expectations.data_context import AbstractDataContext
+from great_expectations.data_context import AbstractDataContext, FileDataContext
+from pathlib import Path
 
 from great_expectations_provider.operators.validate_checkpoint import (
     GXValidateCheckpointOperator,
@@ -14,16 +15,22 @@ from integration.conftest import rand_name
 
 
 class TestValidateCheckpointOperator:
+    """Test cases for GXValidateCheckpointOperator with different context types."""
+
     COL_NAME = "my_column"
 
     @pytest.fixture
-    def configure_checkpoint(
-        self,
-        ensure_checkpoint_cleanup: Callable[[str], None],
-        ensure_validation_definition_cleanup: Callable[[str], None],
-        ensure_suite_cleanup: Callable[[str], None],
-        ensure_data_source_cleanup: Callable[[str], None],
-    ) -> Callable[[AbstractDataContext], gx.Checkpoint]:
+    def data_frame(self) -> pd.DataFrame:
+        """Sample data frame for test cases"""
+        return pd.DataFrame({self.COL_NAME: [1, 2, 3, 4, 5]})
+
+    @pytest.fixture
+    def configure_checkpoint(self) -> Callable[[AbstractDataContext], gx.Checkpoint]:
+        """Configure an arbitrary checkpoint to a given context.
+
+        This will pass for the data_frame fixture.
+        """
+
         def _configure_checkpoint(context: AbstractDataContext) -> gx.Checkpoint:
             batch_definition = (
                 context.data_sources.add_pandas(name=rand_name())
@@ -55,32 +62,102 @@ class TestValidateCheckpointOperator:
                 )
             )
 
-            ensure_checkpoint_cleanup(checkpoint.name)
-            ensure_validation_definition_cleanup(validation_definition.name)
-            ensure_suite_cleanup(suite.name)
-            ensure_data_source_cleanup(batch_definition.data_asset.datasource.name)
-
             return checkpoint
 
         return _configure_checkpoint
 
-    def test_validate_checkpoint_with_cloud(
+    @pytest.fixture
+    def configure_checkpoint_with_cleanup(
         self,
         configure_checkpoint: Callable[[AbstractDataContext], gx.Checkpoint],
+        ensure_checkpoint_cleanup: Callable[[str], None],
+        ensure_validation_definition_cleanup: Callable[[str], None],
+        ensure_suite_cleanup: Callable[[str], None],
+        ensure_data_source_cleanup: Callable[[str], None],
+    ) -> Callable[[AbstractDataContext], gx.Checkpoint]:
+        """Configure an arbitrary checkpoint to a given cloud context.
+
+        The models will be cleaned up when the test ends
+        This will pass for the data_frame fixture.
+        """
+
+        def _configure_checkpoint(context: AbstractDataContext) -> gx.Checkpoint:
+            # get the checkpoint
+            checkpoint = configure_checkpoint(context)
+
+            # ensure cleanup after the test ends
+            ensure_checkpoint_cleanup(checkpoint.name)
+            for vd in checkpoint.validation_definitions:
+                ensure_validation_definition_cleanup(vd.name)
+                ensure_suite_cleanup(vd.suite.name)
+                ensure_data_source_cleanup(vd.data.data_asset.datasource.name)
+
+            # return the checkpoint for use in test
+            return checkpoint
+
+        return _configure_checkpoint
+
+    def test_with_cloud_context(
+        self,
+        configure_checkpoint_with_cleanup: Callable[
+            [AbstractDataContext], gx.Checkpoint
+        ],
+        data_frame: pd.DataFrame,
     ) -> None:
-        df = pd.DataFrame({self.COL_NAME: [1, 2, 3, 4, 5]})
+        """Ensure GXValidateCheckpointOperator works with cloud contexts."""
+
         validate_cloud_checkpoint = GXValidateCheckpointOperator(
             context_type="cloud",
             task_id="validate_cloud_checkpoint",
-            configure_checkpoint=configure_checkpoint,
-            batch_parameters={"dataframe": df},
+            configure_checkpoint=configure_checkpoint_with_cleanup,
+            batch_parameters={"dataframe": data_frame},
         )
 
         result = validate_cloud_checkpoint.execute(context={})
 
         assert result["success"] is True
 
-    def test_postgres(
+    def test_with_file_context(
+        self,
+        configure_checkpoint: Callable[[AbstractDataContext], gx.Checkpoint],
+        tmp_path: Path,
+        data_frame: pd.DataFrame,
+    ) -> None:
+        """Ensure GXValidateCheckpointOperator works with file contexts."""
+
+        def configure_context() -> FileDataContext:
+            return gx.get_context(mode="file", project_root_dir=tmp_path)
+
+        validate_cloud_checkpoint = GXValidateCheckpointOperator(
+            configure_file_data_context=configure_context,
+            task_id="validate_cloud_checkpoint",
+            configure_checkpoint=configure_checkpoint,
+            batch_parameters={"dataframe": data_frame},
+        )
+
+        result = validate_cloud_checkpoint.execute(context={})
+
+        assert result["success"] is True
+
+    def test_with_ephemeral_context(
+        self,
+        configure_checkpoint: Callable[[AbstractDataContext], gx.Checkpoint],
+        data_frame: pd.DataFrame,
+    ) -> None:
+        """Ensure GXValidateCheckpointOperator works with ephemeral contexts."""
+
+        validate_cloud_checkpoint = GXValidateCheckpointOperator(
+            context_type="ephemeral",
+            task_id="validate_cloud_checkpoint",
+            configure_checkpoint=configure_checkpoint,
+            batch_parameters={"dataframe": data_frame},
+        )
+
+        result = validate_cloud_checkpoint.execute(context={})
+
+        assert result["success"] is True
+
+    def test_postgres_data_source(
         self,
         table_name: str,
         load_postgres_data: Callable[[list[dict]], None],
@@ -127,7 +204,61 @@ class TestValidateCheckpointOperator:
             )
 
         validate_checkpoint = GXValidateCheckpointOperator(
-            context_type="cloud",
+            context_type="ephemeral",
+            task_id="validate_cloud_checkpoint",
+            configure_checkpoint=configure_checkpoint,
+        )
+
+        result = validate_checkpoint.execute(context={})
+
+        assert result["success"] is True
+
+    def test_filesystem_data_source(
+        self,
+        load_csv_data: Callable[[Path, list[dict]], None],
+        tmp_path: Path,
+    ) -> None:
+        data_location = tmp_path / "data.csv"
+        load_csv_data(
+            data_location,
+            [
+                {"name": "Alice", "age": 30},
+                {"name": "Bob", "age": 31},
+            ],
+        )
+
+        def configure_checkpoint(context: AbstractDataContext) -> gx.Checkpoint:
+            bd = (
+                context.data_sources.add_pandas(name=rand_name())
+                .add_csv_asset(name=rand_name(), filepath_or_buffer=data_location)
+                .add_batch_definition_whole_dataframe(name=rand_name())
+            )
+            suite = context.suites.add(
+                gx.ExpectationSuite(
+                    name=rand_name(),
+                    expectations=[
+                        gxe.ExpectColumnValuesToBeBetween(
+                            column="age",
+                            min_value=0,
+                            max_value=100,
+                        ),
+                        gxe.ExpectTableRowCountToEqual(value=2),
+                    ],
+                )
+            )
+            vd = context.validation_definitions.add(
+                gx.ValidationDefinition(
+                    name=rand_name(),
+                    data=bd,
+                    suite=suite,
+                )
+            )
+            return context.checkpoints.add(
+                gx.Checkpoint(name=rand_name(), validation_definitions=[vd])
+            )
+
+        validate_checkpoint = GXValidateCheckpointOperator(
+            context_type="ephemeral",
             task_id="validate_cloud_checkpoint",
             configure_checkpoint=configure_checkpoint,
         )

--- a/tests/integration/test_validate_checkpoint_operator.py
+++ b/tests/integration/test_validate_checkpoint_operator.py
@@ -107,7 +107,7 @@ class TestValidateCheckpointOperator:
 
         validate_cloud_checkpoint = GXValidateCheckpointOperator(
             context_type="cloud",
-            task_id="validate_cloud_checkpoint",
+            task_id="cloud_context",
             configure_checkpoint=configure_checkpoint_with_cleanup,
             batch_parameters={"dataframe": data_frame},
         )
@@ -129,7 +129,7 @@ class TestValidateCheckpointOperator:
 
         validate_cloud_checkpoint = GXValidateCheckpointOperator(
             configure_file_data_context=configure_context,
-            task_id="validate_cloud_checkpoint",
+            task_id="file_context",
             configure_checkpoint=configure_checkpoint,
             batch_parameters={"dataframe": data_frame},
         )
@@ -147,7 +147,7 @@ class TestValidateCheckpointOperator:
 
         validate_cloud_checkpoint = GXValidateCheckpointOperator(
             context_type="ephemeral",
-            task_id="validate_cloud_checkpoint",
+            task_id="ephemeral_context",
             configure_checkpoint=configure_checkpoint,
             batch_parameters={"dataframe": data_frame},
         )
@@ -204,7 +204,7 @@ class TestValidateCheckpointOperator:
 
         validate_checkpoint = GXValidateCheckpointOperator(
             context_type="ephemeral",
-            task_id="validate_cloud_checkpoint",
+            task_id="postgres_data_source",
             configure_checkpoint=configure_checkpoint,
         )
 
@@ -258,7 +258,7 @@ class TestValidateCheckpointOperator:
 
         validate_checkpoint = GXValidateCheckpointOperator(
             context_type="ephemeral",
-            task_id="validate_cloud_checkpoint",
+            task_id="filesystem_data_source",
             configure_checkpoint=configure_checkpoint,
         )
 


### PR DESCRIPTION
Adds remaining integration tests around GXValidateCheckpointOperator.

**The approach**
* 1 test per context type
* 1 test per category of data source (sql, file system, data frame)

**New stuff**
* Light-weight fixture for writing csv files
* Splits apart the checkpoint configuration fixture so that one fixture creates the checkpoint, and one knows about cleaning it up, since that's only relevant to cloud
* More comments

**Where this strays from the light**
CORE 728 says "Cloud tests should ensure that the validation result can be retrieved from the cloud backend.", but a) our API for that doesn't work, and b) that's testing gx cloud itself, not our interactions with it via the operator, so I think it's fine and reasonable to skip that.