### PR TITLE
[MAINTENANCE] Add lint step to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Install Dependencies
         run: pip install -r test-requirements.txt
 
-      - name: Ruff
+      - name: Ruff Formatter
         run: ruff format --check .
+
+      - name: Ruff Linter
+        run: ruff check .
 
       - name: MyPy
         run: mypy --pretty  --no-error-summary .

--- a/great_expectations_provider/example_dags/example_great_expectations_dag.py
+++ b/great_expectations_provider/example_dags/example_great_expectations_dag.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import great_expectations.expectations as gxe
 import pandas as pd
 from airflow import DAG
-from airflow.models.baseoperator import chain
-
 from airflow.decorators import task
-from great_expectations import ExpectationSuite, ValidationDefinition, Checkpoint
-import great_expectations.expectations as gxe
+from airflow.models.baseoperator import chain
+from great_expectations import Checkpoint, ExpectationSuite, ValidationDefinition
 
 from great_expectations_provider.operators.validate_batch import GXValidateBatchOperator
 from great_expectations_provider.operators.validate_checkpoint import (
@@ -19,9 +19,8 @@ from great_expectations_provider.operators.validate_dataframe import (
 )
 
 if TYPE_CHECKING:
-    from great_expectations.data_context import AbstractDataContext
     from great_expectations.core.batch_definition import BatchDefinition
-    from great_expectations import Checkpoint
+    from great_expectations.data_context import AbstractDataContext
 
 base_path = Path(__file__).parents[2]
 data_dir = base_path / "include" / "data"

--- a/great_expectations_provider/operators/validate_batch.py
+++ b/great_expectations_provider/operators/validate_batch.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
-from typing import Callable, Literal, TYPE_CHECKING
+
+from typing import TYPE_CHECKING, Callable, Literal
 
 from airflow.models import BaseOperator
 
-
 if TYPE_CHECKING:
-    from great_expectations.data_context import AbstractDataContext
+    from airflow.utils.context import Context
+    from great_expectations import ExpectationSuite
     from great_expectations.core.batch import BatchParameters
     from great_expectations.core.batch_definition import BatchDefinition
+    from great_expectations.data_context import AbstractDataContext
     from great_expectations.expectations import Expectation
-    from great_expectations import ExpectationSuite
-    from airflow.utils.context import Context
 
 
 class GXValidateBatchOperator(BaseOperator):

--- a/great_expectations_provider/operators/validate_checkpoint.py
+++ b/great_expectations_provider/operators/validate_checkpoint.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Literal
 
 from airflow.models import BaseOperator
 
-
 if TYPE_CHECKING:
-    from great_expectations.data_context import AbstractDataContext, FileDataContext
-    from great_expectations import Checkpoint
-    from great_expectations.core.batch import BatchParameters
-    from great_expectations.checkpoint.checkpoint import CheckpointDescriptionDict
     from airflow.utils.context import Context
+    from great_expectations import Checkpoint
+    from great_expectations.checkpoint.checkpoint import CheckpointDescriptionDict
+    from great_expectations.core.batch import BatchParameters
+    from great_expectations.data_context import AbstractDataContext, FileDataContext
 
 
 class GXValidateCheckpointOperator(BaseOperator):

--- a/great_expectations_provider/operators/validate_dataframe.py
+++ b/great_expectations_provider/operators/validate_dataframe.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from typing import Callable, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Literal
 
 from airflow.models import BaseOperator
 
-
 if TYPE_CHECKING:
-    from great_expectations.expectations import Expectation
-    from great_expectations import ExpectationSuite
     from airflow.utils.context import Context
+    from great_expectations import ExpectationSuite
+    from great_expectations.expectations import Expectation
     from pandas import DataFrame
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,9 @@ build-backend = "setuptools.build_meta"
 [tool.mypy]
 exclude = ["env/", ".env/","venv/", ".venv/", "build/"]
 follow_untyped_imports = true
+
+[tool.ruff]
+lint.select = [
+    "I",
+    "TC",
+]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,12 +1,12 @@
 import os
-import great_expectations as gx
+import random
+import string
 from typing import Callable, Generator
+
+import great_expectations as gx
+import pytest
 from great_expectations.data_context import AbstractDataContext
 from sqlalchemy import create_engine, text
-
-import pytest
-import string
-import random
 
 
 def rand_name() -> str:

--- a/tests/integration/test_example_dag.py
+++ b/tests/integration/test_example_dag.py
@@ -1,18 +1,11 @@
 import logging
 import pytest
-import sys
 
-from datetime import datetime, timezone
 from functools import cache
-from airflow.exceptions import AirflowSkipException
-from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
-from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session, NEW_SESSION
 from airflow.utils.state import DagRunState, State
-from airflow.utils.types import DagRunType
 from sqlalchemy.orm import Session
 
 log = logging.getLogger(__name__)

--- a/tests/integration/test_example_dag.py
+++ b/tests/integration/test_example_dag.py
@@ -1,10 +1,10 @@
 import logging
-import pytest
-
 from functools import cache
+
+import pytest
 from airflow.models.dagbag import DagBag
 from airflow.utils.db import create_default_connections
-from airflow.utils.session import provide_session, NEW_SESSION
+from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State
 from sqlalchemy.orm import Session
 

--- a/tests/integration/test_validate_checkpoint_operator.py
+++ b/tests/integration/test_validate_checkpoint_operator.py
@@ -1,10 +1,9 @@
-import pytest
-
-import pandas as pd
-
 from typing import Callable
+
 import great_expectations as gx
 import great_expectations.expectations as gxe
+import pandas as pd
+import pytest
 from great_expectations.data_context import AbstractDataContext
 
 from great_expectations_provider.operators.validate_checkpoint import (

--- a/tests/unit/test_validate_batch_operator.py
+++ b/tests/unit/test_validate_batch_operator.py
@@ -1,5 +1,5 @@
 import json
-from typing import Literal, Final
+from typing import Literal
 from unittest.mock import Mock
 import pytest
 from great_expectations.data_context import AbstractDataContext
@@ -15,7 +15,6 @@ from pytest_mock import MockerFixture
 from great_expectations.core import (
     ExpectationValidationResult,
 )
-from airflow.operators.python import PythonOperator
 
 
 class TestValidateBatchOperator:

--- a/tests/unit/test_validate_batch_operator.py
+++ b/tests/unit/test_validate_batch_operator.py
@@ -1,20 +1,21 @@
 import json
 from typing import Literal
 from unittest.mock import Mock
-import pytest
-from great_expectations.data_context import AbstractDataContext
-from great_expectations.core.batch_definition import BatchDefinition
 
-from great_expectations_provider.operators.validate_batch import GXValidateBatchOperator
 import pandas as pd
+import pytest
 from great_expectations import ExpectationSuite
+from great_expectations.core import (
+    ExpectationValidationResult,
+)
+from great_expectations.core.batch_definition import BatchDefinition
+from great_expectations.data_context import AbstractDataContext
 from great_expectations.expectations import (
     ExpectColumnValuesToBeInSet,
 )
 from pytest_mock import MockerFixture
-from great_expectations.core import (
-    ExpectationValidationResult,
-)
+
+from great_expectations_provider.operators.validate_batch import GXValidateBatchOperator
 
 
 class TestValidateBatchOperator:

--- a/tests/unit/test_validate_checkpoint_operator.py
+++ b/tests/unit/test_validate_checkpoint_operator.py
@@ -9,7 +9,7 @@ from pytest_mock import MockerFixture
 from great_expectations_provider.operators.validate_checkpoint import (
     GXValidateCheckpointOperator,
 )
-from great_expectations.data_context import AbstractDataContext, FileDataContext
+from great_expectations.data_context import AbstractDataContext
 import pandas as pd
 from great_expectations import ExpectationSuite
 from great_expectations.expectations import ExpectColumnValuesToBeInSet

--- a/tests/unit/test_validate_checkpoint_operator.py
+++ b/tests/unit/test_validate_checkpoint_operator.py
@@ -1,18 +1,17 @@
 import json
 from typing import Literal
 from unittest.mock import Mock
+
+import pandas as pd
 import pytest
-from great_expectations import ValidationDefinition
-from great_expectations import Checkpoint
+from great_expectations import Checkpoint, ExpectationSuite, ValidationDefinition
+from great_expectations.data_context import AbstractDataContext
+from great_expectations.expectations import ExpectColumnValuesToBeInSet
 from pytest_mock import MockerFixture
 
 from great_expectations_provider.operators.validate_checkpoint import (
     GXValidateCheckpointOperator,
 )
-from great_expectations.data_context import AbstractDataContext
-import pandas as pd
-from great_expectations import ExpectationSuite
-from great_expectations.expectations import ExpectColumnValuesToBeInSet
 
 
 class TestValidateCheckpointOperator:

--- a/tests/unit/test_validate_dataframe_operator.py
+++ b/tests/unit/test_validate_dataframe_operator.py
@@ -3,16 +3,16 @@ from typing import Literal
 from unittest.mock import Mock
 
 import pandas as pd
-from great_expectations import ExpectationSuite
-from great_expectations.expectations import ExpectColumnValuesToBeInSet
-
 import pytest
-from pytest_mock import MockerFixture
-from great_expectations_provider.operators.validate_dataframe import (
-    GXValidateDataFrameOperator,
-)
+from great_expectations import ExpectationSuite
 from great_expectations.core import (
     ExpectationValidationResult,
+)
+from great_expectations.expectations import ExpectColumnValuesToBeInSet
+from pytest_mock import MockerFixture
+
+from great_expectations_provider.operators.validate_dataframe import (
+    GXValidateDataFrameOperator,
 )
 
 


### PR DESCRIPTION
Looks like in https://github.com/great-expectations/gx-airflow-provider/commit/026cb66c3913295fc2560d9f6fe39cd9cdda6ed2 we switched from the linter to the formatter. Now we have both 🎉 

We previously had ruff formatter on, but not linting. This adds linting, and opts into 2 categories or rules:
* flake8 type checking: https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc
* isort: https://docs.astral.sh/ruff/rules/#isort-i