### PR TITLE
[FEATURE] Allow configure_file_data_context to return a generator

### DIFF
--- a/great_expectations_provider/operators/validate_checkpoint.py
+++ b/great_expectations_provider/operators/validate_checkpoint.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Literal
+from typing import TYPE_CHECKING, Callable, Generator, Literal
 
 from airflow.models import BaseOperator
 
@@ -18,7 +18,9 @@ class GXValidateCheckpointOperator(BaseOperator):
         configure_checkpoint: Callable[[AbstractDataContext], Checkpoint],
         batch_parameters: BatchParameters | None = None,
         context_type: Literal["ephemeral", "cloud", "file"] = "ephemeral",
-        configure_file_data_context: Callable[[], FileDataContext] | None = None,
+        configure_file_data_context: Callable[[], FileDataContext]
+        | Callable[[], Generator[FileDataContext, None, None]]
+        | None = None,
         *args,
         **kwargs,
     ) -> None:

--- a/great_expectations_provider/operators/validate_checkpoint.py
+++ b/great_expectations_provider/operators/validate_checkpoint.py
@@ -4,13 +4,13 @@ import inspect
 from typing import TYPE_CHECKING, Callable, Generator, Literal, cast
 
 from airflow.models import BaseOperator
+from great_expectations.data_context import AbstractDataContext, FileDataContext
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
     from great_expectations import Checkpoint
     from great_expectations.checkpoint.checkpoint import CheckpointDescriptionDict
     from great_expectations.core.batch import BatchParameters
-    from great_expectations.data_context import AbstractDataContext, FileDataContext
 
 
 class GXValidateCheckpointOperator(BaseOperator):

--- a/great_expectations_provider/operators/validate_checkpoint.py
+++ b/great_expectations_provider/operators/validate_checkpoint.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Callable, Generator, Literal
+from typing import TYPE_CHECKING, Callable, Generator, Literal, cast
 
 from airflow.models import BaseOperator
 
@@ -54,7 +54,10 @@ class GXValidateCheckpointOperator(BaseOperator):
                 file_context_generator = self.configure_file_data_context()
                 gx_context = self._get_value_from_generator(file_context_generator)
             else:
-                gx_context = self.configure_file_data_context()
+                file_context_fn = cast(
+                    Callable[[], FileDataContext], self.configure_file_data_context
+                )
+                gx_context = file_context_fn()
         else:
             gx_context = gx.get_context(mode=self.context_type)
         checkpoint = self.configure_checkpoint(gx_context)

--- a/great_expectations_provider/operators/validate_checkpoint.py
+++ b/great_expectations_provider/operators/validate_checkpoint.py
@@ -87,10 +87,6 @@ class GXValidateCheckpointOperator(BaseOperator):
         except StopIteration:
             pass
         else:
-            # we had an extra yield; we'll raise, but first, let's run out the generator
-            # so it does any teardown/cleanup
-            for _ in generator:
-                ...
             raise RuntimeError(
                 "Generator must yield exactly once; yielded more than once"
             )

--- a/tests/unit/test_validate_checkpoint_operator.py
+++ b/tests/unit/test_validate_checkpoint_operator.py
@@ -193,7 +193,7 @@ class TestValidateCheckpointOperator:
         mock_checkpoint.run.assert_called_once_with(batch_parameters=batch_parameters)
 
     def test_configure_file_data_context_with_without_generator(self) -> None:
-        """Expect that configure_file_data_context can be a generator."""
+        """Expect that configure_file_data_context can just return a DataContext"""
         # arrange
         mock_context = Mock(spec=AbstractDataContext)
         setup = Mock()
@@ -216,11 +216,11 @@ class TestValidateCheckpointOperator:
 
         # assert
         setup.assert_called_once()
-        teardown.assert_not_called()
         configure_checkpoint.assert_called_once_with(mock_context)
+        teardown.assert_not_called()
 
     def test_configure_file_data_context_with_generator(self) -> None:
-        """Expect that configure_file_data_context can be a generator."""
+        """Expect that configure_file_data_context can return a generator that yeidls a DataContext."""
         # arrange
         mock_context = Mock(spec=AbstractDataContext)
         setup = Mock()
@@ -244,5 +244,5 @@ class TestValidateCheckpointOperator:
 
         # assert
         setup.assert_called_once()
-        teardown.assert_called_once()
         configure_checkpoint.assert_called_once_with(mock_context)
+        teardown.assert_called_once()

--- a/tests/unit/test_validate_checkpoint_operator.py
+++ b/tests/unit/test_validate_checkpoint_operator.py
@@ -305,4 +305,4 @@ class TestValidateCheckpointOperator:
 
         # assert
         setup.assert_called_once()
-        teardown.assert_called_once()
+        teardown.assert_not_called()


### PR DESCRIPTION
This allows users to do either of the following:
* pass in a function that returns a data context
* pass in a function that returns a generator that yields a data context so they can perform setup before yielding and teardown after the yield.

There's a bit of ugly logic around edge cases if the generator has <> 1 yield. Since this is ugly, and we're somewhat modeling this around the way pytest fixtures work, here's how pytest does it for reference: https://github.com/pytest-dev/pytest/blob/main/src/_pytest/fixtures.py#L890-L923