### PR TITLE
[MAINTENANCE] Add extras to setup.cfg for optional deps

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,10 +41,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install .
-
-      - name: Install Dependencies
-        run: pip install -r test-requirements.txt
+        run: pip install .[test]
 
       - name: Setup
         run: |
@@ -78,10 +75,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install .
-
-      - name: Install Dependencies
-        run: pip install -r test-requirements.txt
+        run: pip install .[test,spark]
 
       - name: Setup
         run: |
@@ -115,10 +109,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install .
-
-      - name: Install Dependencies
-        run: pip install -r test-requirements.txt
+        run: pip install .[test,spark]
 
       - name: Setup
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[tests]"
+        run: pip install ".[postgresql,tests]"
 
       - name: Setup
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[test]"
+        run: pip install ".[tests]"
 
       - name: Setup
         run: |
@@ -75,7 +75,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[test,spark]"
+        run: pip install ".[tests,spark]"
 
       - name: Setup
         run: |
@@ -109,7 +109,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[test,spark]"
+        run: pip install ".[tests,spark]"
 
       - name: Setup
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[postgresql,tests]"
+        run: pip install .[postgresql,tests]
 
       - name: Setup
         run: |
@@ -75,7 +75,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[tests,spark]"
+        run: pip install .[tests,spark]
 
       - name: Setup
         run: |
@@ -109,7 +109,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[tests,spark]"
+        run: pip install .[tests,spark]
 
       - name: Setup
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install .[test]
+        run: pip install ".[test]"
 
       - name: Setup
         run: |
@@ -75,7 +75,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install .[test,spark]
+        run: pip install ".[test,spark]"
 
       - name: Setup
         run: |
@@ -109,7 +109,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install .[test,spark]
+        run: pip install ".[test,spark]"
 
       - name: Setup
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,7 @@ jobs:
           python-version: 3.12
 
       - name: Install Library
-        run: pip install .
-
-      - name: Install Dependencies
-        run: pip install -r test-requirements.txt
+        run: pip install .[lint]
 
       - name: Ruff Formatter
         run: ruff format --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: 3.12
 
       - name: Install Library
-        run: pip install .[lint]
+        run: pip install ".[lint]"
 
       - name: Ruff Formatter
         run: ruff format --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: 3.12
 
       - name: Install Library
-        run: pip install ".[lint]"
+        run: pip install .[lint]
 
       - name: Ruff Formatter
         run: ruff format --check .

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install .[test]
+        run: pip install ".[test]"
 
       - name: Run Unit Tests
         run: pytest -vvv -m unit tests/unit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[tests]"
+        run: pip install .[tests]
 
       - name: Run Unit Tests
         run: pytest -vvv -m unit tests/unit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,10 +27,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install .
-
-      - name: Install Dependencies
-        run: pip install -r test-requirements.txt
+        run: pip install .[test]
 
       - name: Run Unit Tests
         run: pytest -vvv -m unit tests/unit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Library
-        run: pip install ".[test]"
+        run: pip install ".[tests]"
 
       - name: Run Unit Tests
         run: pytest -vvv -m unit tests/unit

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ python_requires = >=3.9
 packages = find_namespace:
 include_package_data = true
 install_requires =
+    great-expectations>=1.3.1
     apache-airflow>=2.1
     setuptools>=41.0.0
 
@@ -20,8 +21,7 @@ lint =
     mypy==1.14.1
     ruff==0.8.3
     pytest==8.3.4
-    pytest-mock==3.14.0
-    great-expectations[snowflake,postgresql,mssql,bigquery,athena,spark,gcp,azure,s3]>=1.3.1
+    great-expectations[spark, spark-connect]>=1.3.1
 gcp =
     great-expectations[gcp]>=1.3.1
 mssql =

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ lint =
     mypy==1.14.1
     ruff==0.8.3
     pytest==8.3.4
+    pytest-mock==3.14.0
     great-expectations[spark, spark-connect]>=1.3.1
 gcp =
     great-expectations[gcp]>=1.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ packages = find_namespace:
 include_package_data = true
 install_requires =
     apache-airflow>=2.1
-    great-expectations[snowflake,postgresql,mssql,bigquery,athena,spark,gcp,azure,s3]>=1.3.1
     setuptools>=41.0.0
 
 [options.extras_require]
@@ -20,6 +19,9 @@ bigquery =
 lint =
     mypy==1.14.1
     ruff==0.8.3
+    pytest==8.3.4
+    pytest-mock==3.14.0
+    great-expectations[snowflake,postgresql,mssql,bigquery,athena,spark,gcp,azure,s3]>=1.3.1
 gcp =
     great-expectations[gcp]>=1.3.1
 mssql =

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,33 @@ install_requires =
     setuptools>=41.0.0
 
 [options.extras_require]
+athena =
+    great-expectations[athena]>=1.3.1
+azure =
+    great-expectations[azure]>=1.3.1
+bigquery =
+    great-expectations[bigquery]>=1.3.1
+lint =
+    mypy==1.14.1
+    ruff==0.8.3
+gcp =
+    great-expectations[gcp]>=1.3.1
+mssql =
+    great-expectations[mssql]>=1.3.1
+postgresql =
+    great-expectations[postgresql]>=1.3.1
+s3 =
+    great-expectations[s3]>=1.3.1
+snowflake =
+    great-expectations[snowflake]>=1.3.1
+spark =
+    great-expectations[spark, spark-connect]>=1.3.1
+    pyarrow>=4.0.0
 tests =
-    pytest
+    pytest==8.3.4
+    pytest-mock==3.14.0
 
 [options.entry_points]
 apache_airflow_provider=
   provider_info=great_expectations_provider.__init__:get_provider_info
+

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,0 @@
-pyarrow>=4.0.0
-pytest==8.3.4
-pytest-mock==3.14.0
-mypy==1.14.1
-ruff==0.8.3

--- a/tests/integration/test_validate_dataframe_operator.py
+++ b/tests/integration/test_validate_dataframe_operator.py
@@ -1,8 +1,9 @@
-from typing import Callable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
 
 import pandas as pd
 import pytest
-from typing import TYPE_CHECKING
 from great_expectations import ExpectationSuite
 from great_expectations.expectations import ExpectColumnValuesToBeInSet
 
@@ -13,7 +14,6 @@ from integration.conftest import is_valid_gx_cloud_url, rand_name
 
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
-    from pyspark.sql.connect.dataframe import DataFrame as SparkConnectDataFrame
     from pyspark.sql.connect.session import SparkSession as SparkConnectSession
 
 
@@ -90,6 +90,8 @@ class TestGXValidateDataFrameOperator:
 
     @pytest.mark.spark_connect_integration
     def test_spark_connect(self, spark_connect_session: SparkConnectSession) -> None:
+        from pyspark.sql.connect.dataframe import DataFrame as SparkConnectDataFrame
+
         column_name = "col_A"
         task_id = f"test_spark_{rand_name()}"
 

--- a/tests/integration/test_validate_dataframe_operator.py
+++ b/tests/integration/test_validate_dataframe_operator.py
@@ -1,17 +1,20 @@
 from typing import Callable
 
 import pandas as pd
-import pyspark.sql as pyspark
 import pytest
+from typing import TYPE_CHECKING
 from great_expectations import ExpectationSuite
 from great_expectations.expectations import ExpectColumnValuesToBeInSet
-from pyspark.sql.connect.dataframe import DataFrame as SparkConnectDataFrame
-from pyspark.sql.connect.session import SparkSession as SparkConnectSession
 
 from great_expectations_provider.operators.validate_dataframe import (
     GXValidateDataFrameOperator,
 )
 from integration.conftest import is_valid_gx_cloud_url, rand_name
+
+if TYPE_CHECKING:
+    import pyspark.sql as pyspark
+    from pyspark.sql.connect.dataframe import DataFrame as SparkConnectDataFrame
+    from pyspark.sql.connect.session import SparkSession as SparkConnectSession
 
 
 class TestGXValidateDataFrameOperator:
@@ -113,6 +116,8 @@ class TestGXValidateDataFrameOperator:
 
 @pytest.fixture
 def spark_session() -> pyspark.SparkSession:
+    import pyspark.sql as pyspark
+
     session = pyspark.SparkSession.builder.getOrCreate()
     assert isinstance(session, pyspark.SparkSession)
     return session
@@ -120,6 +125,9 @@ def spark_session() -> pyspark.SparkSession:
 
 @pytest.fixture
 def spark_connect_session() -> SparkConnectSession:
+    import pyspark.sql as pyspark
+    from pyspark.sql.connect.session import SparkSession as SparkConnectSession
+
     session = pyspark.SparkSession.builder.remote("sc://localhost:15002").getOrCreate()
     assert isinstance(session, SparkConnectSession)
     return session

--- a/tests/integration/test_validate_dataframe_operator.py
+++ b/tests/integration/test_validate_dataframe_operator.py
@@ -12,7 +12,7 @@ from great_expectations_provider.operators.validate_dataframe import (
 from integration.conftest import is_valid_gx_cloud_url, rand_name
 
 if TYPE_CHECKING:
-    import pyspark.sql as pyspark
+    from pyspark.sql import SparkSession
     from pyspark.sql.connect.dataframe import DataFrame as SparkConnectDataFrame
     from pyspark.sql.connect.session import SparkSession as SparkConnectSession
 
@@ -60,7 +60,9 @@ class TestGXValidateDataFrameOperator:
         assert is_valid_gx_cloud_url(result["result_url"])
 
     @pytest.mark.spark_integration
-    def test_spark(self, spark_session: pyspark.SparkSession) -> None:
+    def test_spark(self, spark_session: SparkSession) -> None:
+        import pyspark.sql as pyspark
+
         column_name = "col_A"
         task_id = f"test_spark_{rand_name()}"
 
@@ -115,7 +117,7 @@ class TestGXValidateDataFrameOperator:
 
 
 @pytest.fixture
-def spark_session() -> pyspark.SparkSession:
+def spark_session() -> SparkSession:
     import pyspark.sql as pyspark
 
     session = pyspark.SparkSession.builder.getOrCreate()

--- a/tests/unit/test_validate_batch_operator.py
+++ b/tests/unit/test_validate_batch_operator.py
@@ -13,7 +13,6 @@ from great_expectations.data_context import AbstractDataContext
 from great_expectations.expectations import (
     ExpectColumnValuesToBeInSet,
 )
-from pytest_mock import MockerFixture
 
 from great_expectations_provider.operators.validate_batch import GXValidateBatchOperator
 


### PR DESCRIPTION
**What this does**
* Adds optional deps as extras in `setup.cfg`
* Uses that pattern instead of the previous test requirements.txt file
* Opts CI jobs into just the deps they need.
* Moves around a couple imports that were previously at the top level and started to fail for jobs that didn't have optional deps installed.

**Note on the mypy deps**
Our type definitions for dataframes allow for both pandas and spark. The base gx install includes pandas, and the spark extras also need to be included for mypy to work.

**What this doesn't do**
CORE-730 says we should install the deps and perform a minimal proof that things work. I think the maintenance burden for a reasonable proof is sufficiently high to make this not worth the effort at the current time. We do have proof that the approach works, as the following extras are used by CI: `tests`, `lint`, `postgresql`, `spark`.